### PR TITLE
Add pyenv docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
+
 # whistab
 
 **W**here **H**ave **I** **S**een **T**his **A**ctor|**A**ctress **B**efore - A simple application to answer a simple question

--- a/README.md
+++ b/README.md
@@ -1,26 +1,16 @@
 # whistab
-Where Have I Seen This Actor|Actress Before - A simple application to answer a simple question
+
+**W**here **H**ave **I** **S**een **T**his **A**ctor|**A**ctress **B**efore - A simple application to answer a simple question
 
 ## Requirements
 - Python `>=3.10.4`
 - `pyenv`, `pyenv-virtualenv`
 - `poetry`
+
+(optional)
 - Vagrant
 - VirtualBox
 
-## Initial set up
+## Get started
 
-- move to the project directory
-    ```bash
-    cd whistab
-    ```
-
-- create the Vagrant box
-    ```bash
-    vagrant up 2>&1 | tee -a $(date +%F)-vagrant-up.log
-    ```
-
-- wait until the Vagrant box is up, then
-    ```bash
-    vagrant ssh
-    ```
+Go to [docs/get-started.md](docs/get-started.md)

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,0 +1,60 @@
+# Create a development environment
+
+It is possible to use [Vagrant](#vagrant) or [pyenv](#pyenv) to create the environment.
+
+After creating the environment continue with [Install the requirements](#install-the-requirements).
+
+## Vagrant
+
+- move to the project directory
+    ```bash
+    cd whistab
+    ```
+
+- create the Vagrant box
+    ```bash
+    vagrant up 2>&1 | tee -a $(date +%F)-vagrant-up.log
+    ```
+
+- wait until the Vagrant box is up, then
+    ```bash
+    vagrant ssh
+    ```
+
+- go to the next section to [install the requirements](#install-the-requirements)
+
+## Pyenv
+
+- install `pyenv` ([documentation](https://github.com/pyenv/pyenv#installation)) and `pyenv-virtualenv` ([documentation](https://github.com/pyenv/pyenv-virtualenv#installation))
+
+
+- install Python `3.10.4`
+  ```bash
+  pyenv install 3.10.4
+  ```
+
+- create a virtual environment
+  ```bash
+  pyenv virtualenv 3.10.4 whistab-3-10-4
+  ```
+
+- activate the virtual environment
+  ```bash
+  pyenv activate whistab-3-10-4
+  ```
+
+- go to the next section to [install the requirements](#install-the-requirements)
+
+# Install the requirements
+
+Make sure to install the requirements in the development environment. Run `pip` while the `pyenv-virtualenv` is active, or while logged in on the Vagrant box).
+
+- update `pip`
+  ```bash
+  pip install --upgrade pip
+  ```
+
+- install the requirements
+  ```bash
+  pip install -r requirements.txt
+  ```


### PR DESCRIPTION
With this PR:
- add the documentation for `pyenv` and `pyenv-virtualenv`
- create a `docs` directory
- move the "Getting started" section to a separate file
- add "Code style: Black"

Closes #3 